### PR TITLE
Update curriculum model and replace auth guards with JwtCommonAuthGuard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   database:
     container_name: acs-website-database
-    image: postgres:latest
+    image: postgres:18
     environment:
       POSTGRES_USER: admin
       POSTGRES_PASSWORD: admin
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./databasepg:/var/lib/postgresql
     healthcheck:
-      test: [ 'CMD-SHELL', 'pg_isready -U admin -d acs-website' ]
+      test: ['CMD-SHELL', 'pg_isready -U admin -d acs-website']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -34,7 +34,11 @@ services:
       database:
         condition: service_healthy
     healthcheck:
-      test: [ 'CMD-SHELL', 'curl -f http://localhost:${PORT}/api/v1/health || exit 1' ]
+      test:
+        [
+          'CMD-SHELL',
+          'curl -f http://localhost:${PORT}/api/v1/health || exit 1',
+        ]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/src/modules/auth/auth.controller.v2.ts
+++ b/src/modules/auth/auth.controller.v2.ts
@@ -33,8 +33,8 @@ interface CommonJwtRequest {
 })
 export class AuthControllerV2 {
   constructor(
-    private authService: AuthService,
-    private userFactory: UsersFactory,
+    private readonly authService: AuthService,
+    private readonly userFactory: UsersFactory,
   ) {}
 
   @UseGuards(CommonAuthGuard)
@@ -70,5 +70,17 @@ export class AuthControllerV2 {
     const { userId } = req.user;
     const user = await this.authService.getUserData(userId);
     return success(user, HttpStatus.OK);
+  }
+
+  @UseGuards(JwtCommonAuthGuard)
+  @Post('logout')
+  logout(
+    @Request() req: CommonJwtRequest,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    res.clearCookie('refreshToken');
+    res.clearCookie('accessToken');
+
+    return success(null, HttpStatus.OK);
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -17,14 +17,14 @@ import { appDominain } from 'src/config/config';
 @Injectable()
 export class AuthService {
   constructor(
-    private userRepository: IUserRepository,
-    private RoleRepository: IRoleRepository,
-    private jwtService: JwtService,
-    private passwordService: PasswordService,
-    private usersService: UsersService,
-    private refresherTokenRepository: IRefresherTokenRepository,
-    private authRepository: IAuthRepository,
-    private emailService: MailService,
+    private readonly userRepository: IUserRepository,
+    private readonly RoleRepository: IRoleRepository,
+    private readonly jwtService: JwtService,
+    private readonly passwordService: PasswordService,
+    private readonly usersService: UsersService,
+    private readonly refresherTokenRepository: IRefresherTokenRepository,
+    private readonly authRepository: IAuthRepository,
+    private readonly emailService: MailService,
   ) {}
 
   async validateUser(


### PR DESCRIPTION
Enhance the curriculum model by adding a title field and updating related DTOs and services. Replace instances of JwtAuthGuard with JwtCommonAuthGuard across various controllers to standardize authentication. Update PostgreSQL image version and improve healthcheck formatting.